### PR TITLE
adding extra - to command line argument for tf_data_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ python nn/train.py \
   --seed 123 \ # Random seed for reproducibility
   --append_seed_to_ckpt_dir \ # This will add seed information to the checkpoint directory name
   --ckpt_dir $DATA/ckpts/split_$SPLIT/ \  # Where to save model checkpoints
-  -tf_data_dir $DATA_DIR/nn_dataset \
+  --tf_data_dir $DATA_DIR/nn_dataset \
   --generate_data # Previously generated data is processed to fit NN data pipeline, only required once
 ```


### PR DESCRIPTION
changing -tf_data_dir to --tf_data_dir, as the valid command line flags for train.py are --tf_data_dir or -fd for TF_DATA_DIR